### PR TITLE
[FR] Add Demo Video iframe

### DIFF
--- a/docs/etoe_reference_example.md
+++ b/docs/etoe_reference_example.md
@@ -9,6 +9,15 @@ Check out the [Quick Start Slides](./_static/DaC_Rolling_your_own_Detections_as_
 
 If you’re starting from scratch and would like to get quickly started, here are the high-level instructions. These steps assume you are familiar with the considerations associated with the various steps and elect to follow the detection-rules VCS approach to manage rules. It also assumes advanced configurations are not applied.
 
+### Demo Video
+
+Take a look at an example of how you can use some of our DaC features. The repo used in this example can be found [here](https://github.com/eric-forte-elastic/detection-rules-dac-demo)
+
+
+<div style="position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden; max-width: 100%; height: auto;">
+    <iframe src="https://drive.google.com/file/d/1XMPSdgjZipa94xufv_4byVrMm-0XaKZh/preview" width="640" height="480" allow="autoplay"></iframe>
+</div>
+
 ### Locally
 
 **Steps:**

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,8 +8,6 @@
 
 ⚠️ Note: The alpha detection-rules [DAC-feature](https://github.com/elastic/detection-rules/tree/DAC-feature) branch, content within these [slides](./_static/DaC_Rolling_your_own_Detections_as_Code.pdf), and this reference guide are subject to change. Once we finally migrate the changes to the `main` branch, we will update the content accordingly.
 
-
-
 ```{toctree}
 :maxdepth: 2
 :caption: Documentation

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,15 +9,6 @@
 ⚠️ Note: The alpha detection-rules [DAC-feature](https://github.com/elastic/detection-rules/tree/DAC-feature) branch, content within these [slides](./_static/DaC_Rolling_your_own_Detections_as_Code.pdf), and this reference guide are subject to change. Once we finally migrate the changes to the `main` branch, we will update the content accordingly.
 
 
-.. dropdown:: Demo Video
-
-    Take a look at an example of how you can use some of our DaC features. The repo used in this example can be found [here](https://github.com/eric-forte-elastic/detection-rules-dac-demo)
-
-    .. raw:: html
-
-        <div style="position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden; max-width: 100%; height: auto;">
-            <iframe src="https://drive.google.com/file/d/1XMPSdgjZipa94xufv_4byVrMm-0XaKZh/preview" width="640" height="480" allow="autoplay"></iframe>
-        </div>
 
 ```{toctree}
 :maxdepth: 2

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,6 +8,17 @@
 
 ⚠️ Note: The alpha detection-rules [DAC-feature](https://github.com/elastic/detection-rules/tree/DAC-feature) branch, content within these [slides](./_static/DaC_Rolling_your_own_Detections_as_Code.pdf), and this reference guide are subject to change. Once we finally migrate the changes to the `main` branch, we will update the content accordingly.
 
+
+.. dropdown:: Demo Video
+
+    Take a look at an example of how you can use some of our DaC features. The repo used in this example can be found [here](https://github.com/eric-forte-elastic/detection-rules-dac-demo)
+
+    .. raw:: html
+
+        <div style="position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden; max-width: 100%; height: auto;">
+            <iframe src="https://drive.google.com/file/d/1XMPSdgjZipa94xufv_4byVrMm-0XaKZh/preview" width="640" height="480" allow="autoplay"></iframe>
+        </div>
+
 ```{toctree}
 :maxdepth: 2
 :caption: Documentation


### PR DESCRIPTION
## Summary

This PR adds a demo video drop down to the main index page of our DaC docs. 

Additional [context](https://github.com/readthedocs/readthedocs.org/issues/879) for the formatting. 