### PR TITLE
[FR] Update Command References

### DIFF
--- a/docs/core_components_and_governance_models_of_dac.md
+++ b/docs/core_components_and_governance_models_of_dac.md
@@ -144,7 +144,7 @@ Dual syncing between Elastic Security and a Version Control System (VCS) embodie
 |                                                                                        |
 | -------------------------------------------------------------------------------------- |
 | <img src="_static/dual_sync_overall_diagram.png" style="width:5.94271in;height:5.84793in" alt="Dual Sync Diagram"/> |
-| <center>*Figure 2: Combining Multiple Options to Duel Sync Rules* </center>                                    |
+| <center>*Figure 2: Combining Multiple Options to Dual Sync Rules* </center>                                    |
 
 #### Considerations
 

--- a/docs/internals_of_the_detection_rules_repo.md
+++ b/docs/internals_of_the_detection_rules_repo.md
@@ -67,7 +67,7 @@ The miscellaneous folder [detection_rules/etc](https://github.com/elastic/detect
 
 The detection-rules Python command line interface (CLI) is designed initially to support internal Elastic rule management, however, it also includes DaC options to manage custom rules. Users can manage rules locally to validate their TOML files against the defined schema dataclasses, interact with Elastic Security to sync rule updates, or even execute RTAs just to name a few. See the [CLI.md](https://github.com/elastic/detection-rules/blob/main/CLI.md) for more details.
 
-The CLI contains more options than needed to perform standard DAC operations. Therefore, we have grouped the relevant DAC commands under <name>.
+The CLI contains more options than needed to perform standard DAC operations. Therefore, we have grouped the relevant DAC commands under custom-rules.
 
 **Steps:**
 


### PR DESCRIPTION
## Summary

This PR updates a few references that were made during the DaC alpha to commands that have different names, primarily the `dac init` -> `custom-rules setup-config`. Additionally this addresses a few typos. 


For more detail see [Slack](https://elastic.slack.com/archives/C06AXCN9JLX).