### PR TITLE
Version Bump

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -22,7 +22,7 @@ copyright = '2024, Elastic'
 author = 'mika.ayenson@elastic.co,eric.forte@elastic.co,justin.ibarra@elastic.co'
 
 # The full version, including alpha/beta/rc tags
-release = '0.2.0-beta'
+release = '0.3.0'
 
 
 # -- General configuration ---------------------------------------------------


### PR DESCRIPTION
## Summary

A quick version bump to indicate that DaC is not in beta anymore. This version is not the version of the DaC capability, rather it is the docs, but the `beta` in the version is confusing and unnecessary. 